### PR TITLE
Added missing include that caused station transfers with existing inventories to fail

### DIFF
--- a/src/app/fleets.ts
+++ b/src/app/fleets.ts
@@ -581,6 +581,7 @@ export default function addFleetsRoutes(router: Router) {
                     userId: res.locals.user.id,
                     systemId: systemOfFleet.id,
                 },
+                include: [{ model: Inventory, required: true }],
                 transaction,
                 lock: true,
             });

--- a/src/seedDevData.ts
+++ b/src/seedDevData.ts
@@ -15,7 +15,7 @@ async function seedDevData() {
         token: "longwelwind",
     });
 
-    await Inventory.bulkCreate([{ id: UUIDV4_1 }]);
+    await Inventory.bulkCreate([{ id: UUIDV4_1, capacity: 10 }]);
 
     await InventoryItem.bulkCreate([
         { inventoryId: UUIDV4_1, resourceId: "iron", quantity: 10 },
@@ -31,7 +31,7 @@ async function seedDevData() {
     ]);
 
     await FleetComposition.bulkCreate([
-        { fleetId: UUIDV4_1, shipTypeId: "miner", quantity: 1 },
+        { fleetId: UUIDV4_1, shipTypeId: "miner_mk_i", quantity: 1 },
     ]);
 }
 


### PR DESCRIPTION
The first time a user transfers cargo to a station, a create call is made in the database to create the inventory. On subsequent transfers, however, the findOne call was not expanding the inventory so this property was undefined when attempting to use it, causing a server error. I added a unit test that should properly catch replicate this condition, but it has been hit-or-miss as to whether it runs, which is why I marked it as BROKEN in the commit.

I also noticed that the seedDevData function needed to be updated with recent changes, so I fixed this as well so it no longer throws an error.