### PR TITLE
Added serializer for shipyard modules

### DIFF
--- a/src/app/systems.modules.test.ts
+++ b/src/app/systems.modules.test.ts
@@ -50,6 +50,48 @@ describe("/v1/systems/{systemId}/modules", () => {
         ]);
     });
 
+    test("GET /v1/systems/{systemId}/station/modules pass shipyard", async () => {
+        await seedTestData({
+            systems: {
+                omega: {
+                    modules: {
+                        [UUIDV4_1]: [
+                            {
+                                id: UUIDV4_1,
+                                moduleTypeId: "refinery-super-alloy",
+                                level: 1,
+                            },
+                        ],
+                    },
+                },
+                "mega-torox": {
+                    modules: {
+                        [UUIDV4_1]: [
+                            {
+                                id: UUIDV4_2,
+                                moduleTypeId: "shipyard",
+                                level: 1,
+                            },
+                        ],
+                    },
+                },
+            },
+        });
+
+        const res = await request(app)
+            .get("/v1/systems/mega-torox/station/modules/")
+            .set("Authorization", "Bearer longwelwind");
+
+        expect(res.status).toEqual(200);
+        expect(res.body.items).toEqual([
+            {
+                moduleTypeId: "shipyard",
+                kind: "shipyard",
+                level: 1
+            },
+        ]);
+    });
+
     test("POST /v1/systems/{systemId}/station/modules/build when building a new module", async () => {
         await seedTestData({
             users: {

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -161,6 +161,10 @@ export function serializeModule(module: Module) {
                       finishTime: job.finishTime.toISOString(),
                   })),
               }
+            : module.moduleType.kind == "shipyard"
+            ? {
+                kind: "shipyard" as const
+            }
             : (() => {
                   throw new Error();
               })()),


### PR DESCRIPTION
As soon as I built my first shipyard, I started getting 500 errors whenever I called the `systems/{systemId}/station/modules` endpoint for that system. It turned out that the module serializer was only set up to handle refineries. By adding one more option to the list, it works now for shipyards, too.